### PR TITLE
Add a new default TypeConverter for LocalDate

### DIFF
--- a/stripes-web/src/main/java/org/stripesframework/web/validation/DefaultTypeConverterFactory.java
+++ b/stripes-web/src/main/java/org/stripesframework/web/validation/DefaultTypeConverterFactory.java
@@ -16,6 +16,7 @@ package org.stripesframework.web.validation;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class DefaultTypeConverterFactory implements TypeConverterFactory {
     */
    @Override
    public void init( final Configuration configuration ) {
-       _configuration = configuration;
+      _configuration = configuration;
       _cache = new TypeHandlerCache<>();
       _cache.setSearchHierarchy(false);
 
@@ -131,6 +132,7 @@ public class DefaultTypeConverterFactory implements TypeConverterFactory {
       _cache.add(Object.class, ObjectTypeConverter.class);
       _cache.add(Character.class, CharacterTypeConverter.class);
       _cache.add(Character.TYPE, CharacterTypeConverter.class);
+      _cache.add(LocalDate.class, LocalDateTypeConverter.class);
    }
 
    /** Provides subclasses with access to the configuration provided at initialization. */

--- a/stripes-web/src/main/java/org/stripesframework/web/validation/LocalDateTypeConverter.java
+++ b/stripes-web/src/main/java/org/stripesframework/web/validation/LocalDateTypeConverter.java
@@ -1,0 +1,26 @@
+package org.stripesframework.web.validation;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Locale;
+
+
+/**
+ * Converts a ISO-8601 formatted string (e.g. "2020-01-01") to a LocalDate.
+ */
+public class LocalDateTypeConverter implements TypeConverter<LocalDate> {
+
+   @Override
+   public LocalDate convert( String input, Class<? extends LocalDate> targetType, Collection<ValidationError> errors ) {
+      try {
+         return LocalDate.parse(input);
+      }
+      catch ( Exception e ) {
+         errors.add(new ScopedLocalizableError("converter.localDate", "invalidDate"));
+         return null;
+      }
+   }
+
+   @Override
+   public void setLocale( Locale locale ) {}
+}

--- a/stripes-web/src/main/resources/StripesResources.properties
+++ b/stripes-web/src/main/resources/StripesResources.properties
@@ -45,6 +45,7 @@ converter.integer.outOfRange=The value ({1}) entered in field {0} was out of the
 converter.float.outOfRange=The value ({1}) entered in field {0} was out of the range {2} to {3}
 converter.enum.notAnEnumeratedValue=The value "{1}" is not a valid value for field {0}
 converter.date.invalidDate=The value ({1}) entered in field {0} must be a valid date
+converter.localDate.invalidDate=The value ({1}) entered in field {0} must be a valid date
 converter.email.invalidEmail=The value ({1}) entered is not a valid email address
 converter.creditCard.invalidCreditCard=The value ({1}) entered is not a valid credit card number
 

--- a/stripes-web/src/test/java/org/stripesframework/web/validation/LocalDateTypeConverterTest.java
+++ b/stripes-web/src/test/java/org/stripesframework/web/validation/LocalDateTypeConverterTest.java
@@ -1,0 +1,29 @@
+package org.stripesframework.web.validation;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+
+class LocalDateTypeConverterTest extends TypeConverterTest<LocalDateTypeConverter, LocalDate> {
+
+   @Test
+   void testStringToLocalDate() {
+      final String input = "2020-01-02";
+
+      whenTypeIsConverted(input);
+
+      thenResultIs(LocalDate.parse(input));
+      thenValidationSucceeds();
+   }
+
+   @Test
+   public void testStringToLocalDate_CannotParseString() {
+      final String input = "01.01.2020";
+
+      whenTypeIsConverted(input);
+
+      thenResultIs(null);
+      thenValidationFails();
+   }
+}


### PR DESCRIPTION
As suggested in https://github.com/Chrono24/stripes/issues/7#issuecomment-836285532 i added a new TypeConverter for a LocalDate, so that you don't have to set it manually in the @Validation annotation.
Tested with unit tests and in our application.